### PR TITLE
build: remove base-directory from buildspec

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -16,7 +16,6 @@ phases:
         commands:
             - echo Build completed on `date`
 artifacts:
-    base-directory: dist
     files:
         - '**/*'
 cache:


### PR DESCRIPTION
This should resolve an issue with deployment, as the CodeBuild was passing but the code artifact only included the final app.js file due to `build-directory: dist` in the buildspec. Perhaps only having the built app.js file in the code artifact is correct, but currently it's blocking deployment.